### PR TITLE
fix: 修复onError和onProgress不回调的问题

### DIFF
--- a/harmony/fast_image/src/main/cpp/FastImageViewComponentInstance.cpp
+++ b/harmony/fast_image/src/main/cpp/FastImageViewComponentInstance.cpp
@@ -117,12 +117,17 @@ void FastImageViewComponentInstance::onPropsChanged(SharedConcreteProps const &p
 
 FastImageNode &FastImageViewComponentInstance::getLocalRootArkUINode() { return m_imageNode; }
 
+void FastImageViewComponentInstance::onProgress(uint32_t loaded, uint32_t total) {
+    if (m_eventEmitter) {
+        m_eventEmitter->onFastImageProgress({static_cast<int>(loaded), static_cast<int>(total)});
+    }
+}
+
 void FastImageViewComponentInstance::onComplete(float width, float height) {
     if (m_eventEmitter == nullptr) {
         return;
     }
     m_eventEmitter->onFastImageLoad({width, height});
-    m_eventEmitter->onFastImageProgress({1, 1});
     m_eventEmitter->onFastImageLoadEnd({});
 }
 
@@ -130,7 +135,7 @@ void FastImageViewComponentInstance::onError(int32_t errorCode) {
     if (m_eventEmitter == nullptr) {
         return;
     }
-    m_eventEmitter->onFastImageLoadEnd({});
+    m_eventEmitter->onFastImageError({});
 }
 
 void FastImageViewComponentInstance::onLoadStart() {

--- a/harmony/fast_image/src/main/cpp/FastImageViewComponentInstance.h
+++ b/harmony/fast_image/src/main/cpp/FastImageViewComponentInstance.h
@@ -23,6 +23,7 @@ public:
     //     void onStateChanged(SharedConcreteState const &state) override;
 
     void onComplete(float width, float height) override;
+    void onProgress(uint32_t loaded, uint32_t total) override;
     void onError(int32_t errorCode) override;
     void onLoadStart();
 


### PR DESCRIPTION
# Summary
解决加载图片时onError和onProgress不回调的问题

# Test Plan
demo地址 https://github.com/react-native-oh-library/RNOHDCS/blob/main/react-native-fast-image/FastImageDemo_callback_fix.tsx
