### PR TITLE
fix:修复ctx里获取不到arkTSMessageHub的问题

### DIFF
--- a/harmony/fast_image/src/main/cpp/FastImageLoaderTurboModule.cpp
+++ b/harmony/fast_image/src/main/cpp/FastImageLoaderTurboModule.cpp
@@ -1,5 +1,6 @@
 #include "FastImageLoaderTurboModule.h"
 #include "RNOH/ArkTSTurboModule.h"
+#include "RNOH/RNInstanceCAPI.h"
 
 using namespace rnoh;
 using namespace facebook;
@@ -17,21 +18,14 @@ rnoh::FastImageLoaderTurboModule::FastImageLoaderTurboModule(
       ARK_ASYNC_METHOD_METADATA(prefetchImageWithMetadata, 3),
       ARK_ASYNC_METHOD_METADATA(queryCache, 1)};
     
-    m_ctx.taskExecutor->runTask(
-      TaskThread::MAIN, [weakInstance = m_ctx] {
-        auto instance = weakInstance.instance.lock();
-        if (!instance) {
-          return;
-        }
-        auto self = instance->getTurboModule<FastImageLoaderTurboModule>("FastImageLoader");
-        if (!self) {
-          return;
-        }
-        if (self->m_FastImageSourceResolver) {
-          return;
-        }
-        
-        self->m_FastImageSourceResolver = std::make_shared<FastImageSourceResolver>(
-            weakInstance.arkTSMessageHub, instance);
-    });
+    if(m_FastImageSourceResolver){
+        return;
+    }
+
+    if(auto instance = m_ctx.instance.lock(); instance != nullptr){
+        m_FastImageSourceResolver = std::make_shared<FastImageSourceResolver>(instance);
+        auto rnInstance = dynamic_cast<RNInstanceCAPI*>(instance.get());
+        rnInstance->addArkTSMessageHandler(m_FastImageSourceResolver);
+    }
+    
 }

--- a/harmony/fast_image/src/main/cpp/FastImageLoaderTurboModule.h
+++ b/harmony/fast_image/src/main/cpp/FastImageLoaderTurboModule.h
@@ -19,12 +19,12 @@ public:
 
     FastImageLoaderTurboModule(const ArkTSTurboModule::Context ctx, const std::string name);
 
-    class FastImageSourceResolver : public ArkTSMessageHub::Observer {
+    class FastImageSourceResolver :  public ArkTSMessageHandler {
     public:
         using Shared = std::shared_ptr<FastImageSourceResolver>;
 
-        FastImageSourceResolver(ArkTSMessageHub::Shared const &subject, RNInstance::Weak rnInstance)
-            : ArkTSMessageHub::Observer(subject), m_rnInstance(rnInstance) {}
+        FastImageSourceResolver(std::weak_ptr<RNInstance> rnInstance)
+            : m_rnInstance(rnInstance) {}
 
         class ImageSourceUpdateListener {
         public:
@@ -103,10 +103,10 @@ public:
         }
 
     protected:
-        virtual void onMessageReceived(const ArkTSMessage &message) override {
-            if (message.name == "UPDATE_FAST_IMAGE_SOURCE_MAP") {
-                auto remoteUri = message.payload["remoteUri"].asString();
-                auto fileUri = message.payload["fileUri"].asString();
+        virtual void handleArkTSMessage(const Context& ctx) override {
+            if (ctx.messageName == "UPDATE_FAST_IMAGE_SOURCE_MAP") {
+                auto remoteUri = ctx.messagePayload["remoteUri"].asString();
+                auto fileUri = ctx.messagePayload["fileUri"].asString();
                 auto it = uriListenersMap.find(remoteUri);
                 if (it == uriListenersMap.end()) {
                     return;


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- 变更FastImageSourceResolver的继承对象，使之不需要取到ctx的arkTSMessageHub即可构造出来
closed #44 

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

