### PR TITLE
fix:修复加载图片出现抖动问题

### DIFF
--- a/harmony/fast_image/src/main/cpp/FastImageNode.cpp
+++ b/harmony/fast_image/src/main/cpp/FastImageNode.cpp
@@ -160,6 +160,14 @@ FastImageNode& FastImageNode::setFocusable(bool focusable) {
   return *this;
 }
 
+FastImageNode& FastImageNode::setAutoResize(bool autoResize) {
+  ArkUI_NumberValue value[] = {{.i32 = static_cast<int32_t>(autoResize)}};
+  ArkUI_AttributeItem item = {value, sizeof(value) / sizeof(ArkUI_NumberValue)};
+  maybeThrow(NativeNodeApi::getInstance()->setAttribute(
+      m_nodeHandle, NODE_IMAGE_AUTO_RESIZE, &item));
+  return *this;
+}
+
 FastImageNode& FastImageNode::setResizeMethod(std::string const& resizeMethod) {
   auto autoResize = (resizeMethod != "scale") ? 1 : 0;
   ArkUI_NumberValue value[] = {{.i32 = autoResize}};

--- a/harmony/fast_image/src/main/cpp/FastImageNode.h
+++ b/harmony/fast_image/src/main/cpp/FastImageNode.h
@@ -40,6 +40,7 @@ class FastImageNode : public ArkUINode {
 
   FastImageNode& resetFocusable();
   FastImageNode& resetResizeMethod();
+  FastImageNode& setAutoResize(bool autoResize);
 
   void onNodeEvent(ArkUI_NodeEventType eventType, EventArgs& eventArgs)
       override;

--- a/harmony/fast_image/src/main/cpp/FastImageViewComponentInstance.cpp
+++ b/harmony/fast_image/src/main/cpp/FastImageViewComponentInstance.cpp
@@ -95,6 +95,7 @@ void FastImageViewComponentInstance::onPropsChanged(SharedConcreteProps const &p
         this->m_source = props->source;
         m_uri = props->source.uri;
         std::string uri = FindLocalCacheByUri(m_uri);
+        this->getLocalRootArkUINode().setAutoResize(true);
         this->getLocalRootArkUINode().setSources(uri, getAbsolutePathPrefix(getBundlePath()));
         
         if (!m_uri.empty()) {


### PR DESCRIPTION
# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：
设置AutoResize 为true，解决图片大小和显示区域不一样出现的抖动问题

## Test Plan

展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。
无
## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

