### PR TITLE
fix:修复无特殊字符的uri下载失败时无法触发onError的错误

### DIFF
--- a/harmony/fast_image/src/main/cpp/FastImageViewComponentInstance.cpp
+++ b/harmony/fast_image/src/main/cpp/FastImageViewComponentInstance.cpp
@@ -198,14 +198,17 @@ void FastImageViewComponentInstance::onError(int32_t errorCode) {
     if (!m_isReload) {
         FastImageSource fastImageSource(m_source);
         std::string uri = fastImageSource.getUri();
-        this->getLocalRootArkUINode().setSources(uri, getAbsolutePathPrefix(getBundlePath()));
         m_isReload = true;
-        return;
+        if (uri.compare(m_source.uri)) {
+            this->getLocalRootArkUINode().setSources(uri, getAbsolutePathPrefix(getBundlePath()));
+            return;
+        }
     }
     if (m_eventEmitter == nullptr) {
         return;
     }
     m_eventEmitter->onFastImageError({});
+    m_eventEmitter->onFastImageLoadEnd({});
 }
 
 void FastImageViewComponentInstance::onLoadStart() {


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- 修复无特殊字符的uri下载失败时无法触发onError的错误
closed #51 

## Test Plan

Test is available in the following links components FastImageErrorExample
https://github.com/react-native-oh-library/RNOHDCS/blob/main/react-native-fast-image/tester/FastImageMothodDemo.tsx

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
