### PR TITLE
fix: 修复在preload下载失败后没有发送LoadEnd事件

### DIFF
--- a/harmony/fast_image/src/main/cpp/FastImageViewComponentInstance.cpp
+++ b/harmony/fast_image/src/main/cpp/FastImageViewComponentInstance.cpp
@@ -179,6 +179,7 @@ void FastImageViewComponentInstance::onImageSourceCacheDownloadFileFail() {
         return;
     }
     m_eventEmitter->onFastImageError({});
+    m_eventEmitter->onFastImageLoadEnd({});
 }
 
 // void FastImageViewComponentInstance::onStateChanged(SharedConcreteState const& state) {


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

- preload下载失败后不会发送onLoadEnd事件
closed #58 

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
