### PR TITLE
fix：去除resetSources逻辑

### DIFF
--- a/harmony/fast_image/src/main/cpp/FastImageViewComponentInstance.cpp
+++ b/harmony/fast_image/src/main/cpp/FastImageViewComponentInstance.cpp
@@ -130,20 +130,12 @@ void FastImageViewComponentInstance::onPropsChanged(SharedConcreteProps const &p
         m_uri = props->source.uri;
         std::string uri = FindLocalCacheByUri(m_uri);
         this->getLocalRootArkUINode().setAutoResize(true);
-
-        if (uri.empty()) {
-            if (!props->source.headers.empty()) {
-                this->getLocalRootArkUINode().resetSources();
-                GetHeaderUri(props->source.uri, props->source.headers);
-            } else {
-                this->getLocalRootArkUINode().resetSources();
-            }
+        
+        if (!props->source.headers.empty()) {
+            GetHeaderUri(props->source.uri, props->source.headers);
         } else {
-            if (!props->source.headers.empty() && uri.find("http", 0) == 0) {
-                this->getLocalRootArkUINode().resetSources();
-                GetHeaderUri(props->source.uri, props->source.headers);
-            } else {
-                this->getLocalRootArkUINode().setSources(uri, getAbsolutePathPrefix(getBundlePath()));
+            if(!uri.empty()){
+               this->getLocalRootArkUINode().setSources(uri, getAbsolutePathPrefix(getBundlePath())); 
             }
         }
 


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- 执行resetSources后，OS接收不到后续的图片uri变动信息，这会导致图片后续的地址刷新失败。删除使用resetSources的部分以解决这个问题
- closed #60 

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
