### PR TITLE
fix:修复同时加载复数的相同uri fastimage组件时，如果提前使用preload下载图片，只会有一个组件被更新的问题

### DIFF
--- a/harmony/fast_image/src/main/cpp/FastImageLoaderTurboModule.h
+++ b/harmony/fast_image/src/main/cpp/FastImageLoaderTurboModule.h
@@ -64,6 +64,7 @@ public:
 
             if (auto it = remoteImageSourceMap.find(uri); it != remoteImageSourceMap.end()) {
                 if (it->second == FAST_IMAGE_SOURCE_PENDING) {
+                    addListenerForURI(uri, &listener);
                     return "";
                 }
                 uri = it->second;


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

- 修复同时加载复数的相同uri fastimage组件时，如果提前使用preload下载图片，只会有一个组件被更新的问题。原因：在正在下载预加载图片的时间节点内，除了第一个组件其他都没有被正确添加到uriListenersMap中
closed #63 

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
