### PR TITLE
fix: 修复uri格式化时抛出的异常未处理导致框架显示basic_string错误

### DIFF
--- a/harmony/fast_image/src/main/cpp/FastImageViewComponentInstance.cpp
+++ b/harmony/fast_image/src/main/cpp/FastImageViewComponentInstance.cpp
@@ -202,7 +202,7 @@ void FastImageViewComponentInstance::onError(int32_t errorCode) {
         FastImageSource fastImageSource(m_source);
         std::string uri = fastImageSource.getUri();
         m_isReload = true;
-        if (uri.compare(m_source.uri)) {
+        if (uri != m_source.uri) {
             this->getLocalRootArkUINode().setSources(uri, getAbsolutePathPrefix(getBundlePath()));
             return;
         }


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

- 修复uri格式化抛出的异常未处理的问题
closed #69

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
